### PR TITLE
remove Ben Good from people menu

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -175,8 +175,6 @@ entries:
           url: /people/bill-duncan
         - title: Nathan Dunn
           url: /people/nathan-dunn
-        - title: Ben Good
-          url: /people/ben-good
         - title: Nomi Harris
           url: /people/nomi-harris
         - title: Harshad Hegde


### PR DESCRIPTION
Should we add him to emeritus/alumni? We haven't done that for people in the past other than Suzi. We don't want the People menu to get too long. Issue #21 requests addition of "alumnus" status for past projects. Could also do that for people, but will require a bit of work.