### PR TITLE
Fix broken image paths in people, project, and software layouts

### DIFF
--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -5,7 +5,11 @@ layout: default
    <h1 class="post-title-main">{% if page.homepage == true %} {{site.homepage_title}} {% else %}{{ page.title }}{% endif %}</h1>
 </div>
 {% if page.image %}
+{% if page.image contains '://' %}
 <img alt="image" src="{{page.image}}" style="max-width: 350px;" />
+{% else %}
+<img alt="image" src="{{page.url}}{{page.image}}" style="max-width: 350px;" />
+{% endif %}
 {% endif %}
 {% if page.twitter %}
       <iframe style="position: static; visibility: visible; width: 190px; height: 20px;" 

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -8,7 +8,11 @@ layout: default
 <h2>(Not currently active)</h2>
 {% endif %}
 {% if page.logo %}
+{% if page.logo contains '://' %}
 <img alt="logo" src="{{page.logo}}"/>
+{% else %}
+<img alt="logo" src="{{page.url}}{{page.logo}}"/>
+{% endif %}
 {% endif %}
   {% if page.twitter %}
       <iframe style="position: static; visibility: visible; width: 250px; height: 20px;" 

--- a/_layouts/software.html
+++ b/_layouts/software.html
@@ -5,7 +5,11 @@ layout: default
    <h1 class="post-title-main">{% if page.homepage == true %} {{site.homepage_title}} {% else %}{{ page.title }}{% endif %}</h1>
 </div>
 {% if page.logo %}
+{% if page.logo contains '://' %}
 <img alt="logo" src="{{page.logo}}" style="max-width:80px;" />
+{% else %}
+<img alt="logo" src="{{page.url}}{{page.logo}}" style="max-width:80px;" />
+{% endif %}
 {% endif %}
   {% if page.twitter %}
       <iframe style="position: static; visibility: visible; width: 190px; height: 20px;" 


### PR DESCRIPTION
## Summary
- Make relative image/logo `src` attributes absolute by prepending `page.url` in all three layouts (`people.html`, `project.html`, `software.html`)
- External URLs (containing `://`) are left unchanged
- Fixes 404s for **all people profile photos** (~15 people affected) and relative project/software logos (CCDH, Apollo)

## Problem
The layouts used bare relative paths like `<img src="seth.jpg">`. When a page is accessed without a trailing slash (e.g., `/people/seth-carbon` instead of `/people/seth-carbon/`), the browser resolves `seth.jpg` relative to `/people/` rather than `/people/seth-carbon/`, producing a 404.

## Fix
For local filenames, prepend `{{page.url}}` (which always includes the trailing slash for index.md files), producing absolute paths like `/people/seth-carbon/seth.jpg`. External URLs are detected via `contains '://'` and passed through unchanged.

## Test plan
- [ ] Verify people profile photos load correctly (e.g., `/people/seth-carbon`, `/people/nomi-harris`)
- [ ] Verify CCDH project logo loads at `/project/ccdh`
- [ ] Verify Apollo software logo loads at `/software/apollo`
- [ ] Verify external logos still work (e.g., Gene Ontology, Monarch, Exomiser)
- [ ] Test pages both with and without trailing slash

🤖 Generated with [Claude Code](https://claude.com/claude-code)