### PR TITLE
[bot] Harden member-only triage workflow

### DIFF
--- a/.github/workflows/member-only-triage.yml
+++ b/.github/workflows/member-only-triage.yml
@@ -2,7 +2,8 @@
 # repo (drive-by / LLM-generated reports). Acts as github-actions[bot] so
 # no human appears in the event stream. Backstop for the repo-level
 # interaction limit, which GitHub silently expires after six months.
-# Manual sweep of existing issues: Actions tab -> run workflow.
+# Manual dispatch requires explicit issue numbers — there is deliberately
+# no bulk mode, so a mis-click can't sweep-close the whole tracker.
 name: member-only-triage
 
 on:
@@ -11,9 +12,8 @@ on:
   workflow_dispatch:
     inputs:
       issue_numbers:
-        description: 'Comma-separated issue numbers to sweep; blank = all open issues'
-        required: false
-        default: ''
+        description: 'Comma-separated issue numbers to triage (required)'
+        required: true
 
 permissions:
   issues: write
@@ -37,21 +37,29 @@ jobs:
                 await github.rest.issues.getLabel({ owner, repo, name: LABEL });
               } catch (e) {
                 if (e.status !== 404) throw e;
-                await github.rest.issues.createLabel({
-                  owner, repo, name: LABEL, color: 'ededed',
-                  description: 'Closed automatically: author is not a repo collaborator',
-                });
+                try {
+                  await github.rest.issues.createLabel({
+                    owner, repo, name: LABEL, color: 'ededed',
+                    description: 'Closed automatically: author is not a repo collaborator',
+                  });
+                } catch (e2) {
+                  // 422 = a concurrent run created it first; that's fine.
+                  if (e2.status !== 422) throw e2;
+                }
               }
             }
 
+            // Lock before commenting: closes the window where the author can
+            // reply, and the bot's write access lets it comment on a locked
+            // issue anyway.
             async function triage(issue) {
               if (issue.pull_request) return;
               if (TRUSTED.includes(issue.author_association)) return;
               const issue_number = issue.number;
-              await github.rest.issues.createComment({ owner, repo, issue_number, body: COMMENT });
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [LABEL] });
               await github.rest.issues.update({ owner, repo, issue_number, state: 'closed', state_reason: 'not_planned' });
               await github.rest.issues.lock({ owner, repo, issue_number });
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: COMMENT });
               core.notice(`Closed and locked #${issue_number} (author ${issue.user.login}: ${issue.author_association})`);
             }
 
@@ -60,16 +68,24 @@ jobs:
             if (context.eventName === 'issues') {
               await triage(context.payload.issue);
             } else {
-              const wanted = ((context.payload.inputs || {}).issue_numbers || '')
-                .split(',').map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n));
-              if (wanted.length) {
-                for (const n of wanted) {
+              const tokens = ((context.payload.inputs || {}).issue_numbers || '')
+                .split(',').map(s => s.trim()).filter(Boolean);
+              const bad = tokens.filter(t => !/^[0-9]+$/.test(t));
+              if (bad.length || !tokens.length) {
+                core.setFailed(tokens.length
+                  ? `Invalid issue numbers: ${bad.join(', ')}`
+                  : 'issue_numbers is required; there is no bulk mode.');
+                return;
+              }
+              let failed = false;
+              for (const n of [...new Set(tokens.map(Number))]) {
+                try {
                   const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
                   await triage(issue);
+                } catch (e) {
+                  failed = true;
+                  core.error(`#${n}: ${e.message}`);
                 }
-              } else {
-                const open = await github.paginate(github.rest.issues.listForRepo,
-                  { owner, repo, state: 'open', per_page: 100 });
-                for (const issue of open) await triage(issue);
               }
+              if (failed) core.setFailed('One or more issues could not be triaged; see errors above.');
             }


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Fixes from an adversarial review of #101:

- **Manual dispatch now requires explicit issue numbers** — the old blank-input default swept *all* open issues, so a single mis-click on "Run workflow" could mass-close/lock legitimate historical issues. Blank input now fails loudly; there is deliberately no bulk mode (existing drive-bys #98/#99/#100 are already handled).
- **Lock before commenting** — closes the window where the drive-by author could reply before the lock landed; the bot's write access lets it comment on the locked issue afterward.
- **Per-issue error isolation on dispatch** — one API failure no longer aborts the remaining issues, and strict input validation rejects malformed numbers instead of silently mangling them.
- **Label-creation race tolerated** — a concurrent run creating `automated-triage` first no longer fails the job.

_— Posted by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)