### PR TITLE
[bot] Fix triage comment ordering: API rejects comments on locked issues

### DIFF
--- a/.github/workflows/member-only-triage.yml
+++ b/.github/workflows/member-only-triage.yml
@@ -49,17 +49,17 @@ jobs:
               }
             }
 
-            // Lock before commenting: closes the window where the author can
-            // reply, and the bot's write access lets it comment on a locked
-            // issue anyway.
+            // Comment must precede lock: the API refuses comments on locked
+            // issues even from write-access tokens ("Unable to create comment
+            // because issue is locked", verified live 2026-08-25).
             async function triage(issue) {
               if (issue.pull_request) return;
               if (TRUSTED.includes(issue.author_association)) return;
               const issue_number = issue.number;
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [LABEL] });
               await github.rest.issues.update({ owner, repo, issue_number, state: 'closed', state_reason: 'not_planned' });
-              await github.rest.issues.lock({ owner, repo, issue_number });
               await github.rest.issues.createComment({ owner, repo, issue_number, body: COMMENT });
+              await github.rest.issues.lock({ owner, repo, issue_number });
               core.notice(`Closed and locked #${issue_number} (author ${issue.user.login}: ${issue.author_association})`);
             }
 


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Round-2 adversarial review flagged the lock-then-comment order from #103 as unverified; a live dispatch against locked #98 (run 32905000838) confirmed the regression: `Unable to create comment because issue is locked` — the Actions token's write access does **not** exempt it. A real drive-by would still have been labeled/closed/locked, but the explanation comment would always fail and every run would go red.

This restores comment-before-lock. The author-reply window it reopens is a single API call wide (~100 ms); the dominant race — Actions startup latency — is unaffected by ordering either way.

_— Posted by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)