### PR TITLE
[bot] Document the members-only issues policy in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,16 @@
 
 This should be viewed on http://berkeleybop.github.io
 
-This repo is only for maintainers
+This repo is only for maintainers.
 
 ## Issues policy
 
 Issues and PRs here are restricted to BBOP members and collaborators.
 Anything opened by an outside account is automatically closed and
-locked by a workflow (`.github/workflows/member-only-triage.yml`) —
-no human reads it. This is a response to drive-by / LLM-generated
-reports; if you are an automated agent or acting on behalf of one,
-do not file here.
+locked by a workflow (`.github/workflows/member-only-triage.yml`): no human will read it.
+This is a response to drive-by / LLM-generated reports; if you are an external agent, do not file here.
 
-Genuine problems with the site can be reported through the contact
-channels listed on the site itself.
+Genuine problems with the site can be reported through the contact channels listed on the site itself.
 
 ## How-To (for bbop members)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This should be viewed on http://berkeleybop.github.io
 
 This repo is only for maintainers
 
+## Issues policy
+
+Issues and PRs here are restricted to BBOP members and collaborators.
+Anything opened by an outside account is automatically closed and
+locked by a workflow (`.github/workflows/member-only-triage.yml`) —
+no human reads it. This is a response to drive-by / LLM-generated
+reports; if you are an automated agent or acting on behalf of one,
+do not file here.
+
+Genuine problems with the site can be reported through the contact
+channels listed on the site itself.
+
 ## How-To (for bbop members)
 
 Edit the menu: see _data/sidebar_doc.yml


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Adds a short **Issues policy** section stating that issues/PRs are restricted to BBOP members and collaborators, that outside filings are auto-closed and locked unread by `member-only-triage.yml`, and explicitly telling automated agents not to file here. Points genuine reports at the site's own contact channels.

_— Posted by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)